### PR TITLE
add gdt library and refactor build scripts

### DIFF
--- a/.env/Dockerfile
+++ b/.env/Dockerfile
@@ -7,7 +7,7 @@ LABEL description="Custom Docker image for building simpleOS."
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install make
-RUN apt-get install binutils-i686-linux-gnu -y
+RUN apt-get install gcc-i686-linux-gnu -y
 
 VOLUME /root/env
 WORKDIR /root/env

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.out
 *.[oa]
-build/
-dist
+dist/
+targets/**/bin/
+targets/**/obj/

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,16 @@
-dir_src := src
-dir_targets := targets
-dir_build := build
-dir_dist := dist
+DIR_DIST := dist
 
-x86_as := i686-linux-gnu-as
-x86_ld := i686-linux-gnu-ld
-
-path_x86_boot := x86/boot
-
-x86_stage1_objects := $(dir_build)/$(path_x86_boot)/stage1.o
-x86_stage1_bin := $(dir_build)/$(path_x86_boot)/bin/stage1.bin
-
-x86_stage2_objects := $(dir_build)/$(path_x86_boot)/stage2.o $\
-	$(dir_build)/$(path_x86_boot)/text.o $\
-	$(dir_build)/$(path_x86_boot)/protected_mode.o
-x86_stage2_targets := $(dir_targets)/$(path_x86_boot)/stage2.ld
-x86_stage2_bin := $(dir_build)/$(path_x86_boot)/bin/stage2.bin
-
-x86_image := $(dir_dist)/x86/simpleOS.img
-
-$(dir_build)/%.o: $(dir_src)/%.s
-	mkdir -p $(dir $@) && \
-	$(x86_as) --32 $< -o $@
-
-$(x86_stage2_bin): $(x86_stage2_objects) $(x86_stage2_targets)
-	mkdir -p $(dir $@) && \
-	$(x86_ld) $(x86_stage2_objects) -T $(x86_stage2_targets) -o $@
-
-$(x86_stage1_objects): $(x86_stage2_bin)
-
-$(x86_stage1_bin): $(x86_stage1_objects)
-	mkdir -p $(dir $@) && \
-	$(x86_ld) $< -m elf_i386 --oformat binary -Ttext 0x7c00 -e _start -o $@
-
-$(x86_image): $(x86_stage1_bin)
-	mkdir -p $(dir $@) && \
-	cp $< $@
+DIR_X86_SRC := src/x86
 
 .PHONY: x86 clean
 
-# build 'dist/x86/kernel.bin'
-x86: $(x86_image)
+# build 'dist/x86/simpleOS.img'
+x86:
+	$(MAKE) -C $(DIR_X86_SRC) x86
+
+clean-x86:
+	$(MAKE) -C $(DIR_X86_SRC) clean 
 
 # cleans up the development environment
-clean:
-	rm -f *.out && \
-	rm -rf $(dir_build)
-	rm -rf $(dir_dist)
-
-# useful for debugging, pass a variable name and it will print it
-# e.g. 'make build-x86 print-x86_asm_objects'
-print-%  : ; @echo $* = $($*)
+clean: clean-x86
+	rm -rf $(DIR_DIST)

--- a/docker.sh
+++ b/docker.sh
@@ -25,7 +25,7 @@ function build() {
     #   t - tag for image
 
     docker build  \
-        env  \
+        .env  \
         -t "$1"
 }
 

--- a/src/x86/Makefile
+++ b/src/x86/Makefile
@@ -1,0 +1,26 @@
+DIR_TARGETS := ../../targets/x86
+DIR_DIST := ../../dist/x86
+DIR_BOOT := boot
+
+BOOT_BIN := $(DIR_TARGETS)/$(DIR_BOOT)/bin/boot.bin
+
+DIST := $(DIR_DIST)/simpleOS.img
+
+# build bootloader binary
+$(BOOT_BIN):
+	$(MAKE) -C $(DIR_BOOT) x86
+
+# build OS image from bootloader
+#   --> simpleOS.img
+$(DIST): $(BOOT_BIN)
+	mkdir -p $(dir $@) && \
+	cp $(BOOT_BIN) $@
+
+.PHONY: x86 clean
+
+# build x86 OS image
+x86: $(DIST)
+
+clean:
+	$(MAKE) -C $(DIR_BOOT) clean && \
+	rm -rf $(DIR_DIST)

--- a/src/x86/boot/Makefile
+++ b/src/x86/boot/Makefile
@@ -1,0 +1,76 @@
+DIR_SRC := .
+DIR_TARGETS := ../../../targets/x86/boot
+DIR_DIST := ../../../dist/x86/boot
+DIR_OBJ := $(DIR_TARGETS)/obj
+DIR_BIN := $(DIR_TARGETS)/bin
+
+GCC := i686-linux-gnu-gcc
+LD := i686-linux-gnu-ld
+
+CFLAGS := -ffreestanding -fno-pie -m32
+LDFLAGS_STAGE1 := -m elf_i386 --oformat binary -Ttext 0x7c00 -e _stage1
+
+STAGE1_SRC := $(DIR_SRC)/stage1.s
+
+STAGE2_LD := $(DIR_TARGETS)/stage2.ld
+
+STAGE1_OBJ := $(DIR_OBJ)/stage1.o
+STAGE2_OBJ := $(DIR_OBJ)/stage2.o
+PROTECTEDLIB_OBJ := $(DIR_OBJ)/protected_mode.o
+GDTLIB_OBJ := $(DIR_OBJ)/gdt.o
+TEXTLIB_OBJ := $(DIR_OBJ)/text.o
+
+STAGE2_BIN := $(DIR_BIN)/stage2.bin
+BOOT_BIN := $(DIR_BIN)/boot.bin
+
+# compile C files
+$(DIR_OBJ)/%.o: $(DIR_SRC)/%.c
+	mkdir -p $(dir $@) && \
+	$(GCC) $(CFLAGS) -c $< -o $@
+
+# assemble ASM files
+$(DIR_OBJ)/%.o: $(DIR_SRC)/%.s
+	mkdir -p $(dir $@) && \
+	$(GCC) $(CFLAGS) -c $< -o $@
+
+# link stage 2 ASM and stage 2 libraries
+#   --> stage 2 object
+$(STAGE2_BIN): $(STAGE2_OBJ) $\
+			   $(PROTECTEDLIB_OBJ) $\
+			   $(GDTLIB_OBJ) $\
+			   $(TEXTLIB_OBJ)
+	mkdir -p $(dir $@) && \
+	$(LD) \
+		-L $(DIR_OBJ) \
+		-T $(STAGE2_LD) \
+		-o $@
+
+# assemble stage 1 ASM with included stage 2 binary 
+#   --> stage 1 object
+$(STAGE1_OBJ): $(STAGE1_SRC) $(STAGE2_BIN)
+	$(GCC) \
+		$(CFLAGS) \
+		-I $(DIR_SRC) \
+		-I $(DIR_BIN) \
+		-c $(STAGE1_SRC) \
+		-o $(STAGE1_OBJ)
+
+# link stage1 object 
+#   --> bootloader binary
+$(BOOT_BIN): $(STAGE1_OBJ)
+	mkdir -p $(dir $@) && \
+	$(LD) \
+		$(LDFLAGS_STAGE1) \
+		$(STAGE1_OBJ) \
+		-o $(BOOT_BIN)
+
+.PHONY: x86 clean-x86
+
+# build bootloader binary
+x86: $(BOOT_BIN)
+
+# clean bootloader build artifacts
+clean:
+	rm -rf $(DIR_OBJ)
+	rm -rf $(DIR_BIN)
+	rm -rf $(DIR_DIST)

--- a/src/x86/boot/gdt.c
+++ b/src/x86/boot/gdt.c
@@ -1,0 +1,118 @@
+/**
+ *  gdt.c
+ *  - creates GDT segment descriptors as 64-bit uints
+ */
+
+#include <stdint.h>
+
+// each define here sets a specific flag in the descriptor
+// refer to the Intel Architectures Developer's Manual (3-10, vol 3A)
+// or https://wiki.osdev.org/Global_Descriptor_Table#Segment_Descriptor
+// for a description of what each one does
+
+#define SEG_DESCTYPE(x) (x << 0x04)           // descriptor type
+#define SEG_PRIV(x)     ((x & 0x03) << 0x05)  // privilege level
+#define SEG_PRES(x)     (x << 0x07)           // segment present
+#define SEG_AVAIL(x)    (x << 0x0C)           // available for system softw.
+#define SEG_LONG(x)     (x << 0x0D)           // 64-bit code segment
+#define SEG_SIZE(x)     (x << 0x0E)           // default operation size
+#define SEG_GRAN(x)     (x << 0x0F)           // granularity
+
+// descriptor type bits
+
+#define SEG_WRITE(x)    (x << 0x01)  // writeable (data only)
+#define SEG_DIR(x)      (x << 0x02)  // direction (data only)
+#define SEG_READ(x)     (x << 0x01)  // readable (code only)
+#define SEG_CONF(x)     (x << 0x02)  // conforming (code only)
+#define SEG_EXEC(x)     (x << 0x03)  // executable - sets data or code
+
+// data descriptor types (not comprehensive)
+
+#define SEG_DATA_READ_ONLY  SEG_EXEC(0) | SEG_DIR(0) | SEG_WRITE(0)
+#define SEG_DATA_READ_WRITE SEG_EXEC(0) | SEG_DIR(0) | SEG_WRITE(1)
+
+// code descriptor types (not comprehensive)
+
+#define SEG_CODE_EXEC_ONLY  SEG_EXEC(1) | SEG_CONF(0) | SEG_READ(0)
+#define SEG_CODE_EXEC_READ  SEG_EXEC(1) | SEG_CONF(0) | SEG_READ(1)
+
+// segment descriptor definitions
+
+#define GDT_NULL_DSC    0
+
+#define GDT_CODE_PL0    SEG_GRAN(1)     | SEG_SIZE(1) | SEG_LONG(0) | \
+                        SEG_AVAIL(0)    | SEG_PRES(1) | SEG_PRIV(0) | \
+                        SEG_DESCTYPE(1) | SEG_CODE_EXEC_READ
+
+#define GDT_DATA_PL0    SEG_GRAN(1)     | SEG_SIZE(1) | SEG_LONG(0) | \
+                        SEG_AVAIL(0)    | SEG_PRES(1) | SEG_PRIV(0) | \
+                        SEG_DESCTYPE(1) | SEG_DATA_READ_WRITE
+
+#define GDT_CODE_PL3    SEG_GRAN(1)     | SEG_SIZE(1) | SEG_LONG(0) | \
+                        SEG_AVAIL(0)    | SEG_PRES(1) | SEG_PRIV(3) | \
+                        SEG_DESCTYPE(1) | SEG_CODE_EXEC_READ
+
+#define GDT_DATA_PL3    SEG_GRAN(1)     | SEG_SIZE(1) | SEG_LONG(0) | \
+                        SEG_AVAIL(0)    | SEG_PRES(1) | SEG_PRIV(3) | \
+                        SEG_DESCTYPE(1) | SEG_DATA_READ_WRITE
+
+// number of GDT entries, including null descriptor
+
+#define GDT_DSC_CT   5
+
+/**
+ * @brief Create a GDT segment descriptor represented as 64-bit uint.
+ * 
+ * @param base   32-bit address where segment begins
+ * @param limit  20-bit value representing last addressable unit
+ * @param flags  16-bit value representing set of boolean flags
+ * 
+ * @return uint64_t  represents GDT segment descriptor
+ */
+static uint64_t create_descriptor(uint32_t base, uint32_t limit, uint16_t flags) {
+    uint64_t descriptor;
+
+    // high 32 bits
+    descriptor  =  limit        & 0x000F0000;
+    descriptor |= (flags <<  8) & 0x00F0FF00;
+    descriptor |= (base  >> 16) & 0x000000FF;
+    descriptor |=  base         & 0xFF000000;
+    descriptor <<= 32;
+
+    // low 32 bits
+    descriptor |= base << 16;
+    descriptor |= limit & 0x0000FFFF;
+
+    return descriptor;
+}
+
+/**
+ * @brief Create GDT with default entries defined above.
+ * 
+ * @param gdt_ptr  location in mem where GDT should be stored
+ * 
+ * @return uint8_t  size (in bytes) of GDT
+ */
+uint16_t set_gdt(uint64_t* gdt_ptr) {
+    uint64_t gdt_entries[GDT_DSC_CT] = { 
+        create_descriptor(0, 0x00000000, (GDT_NULL_DSC)),
+        create_descriptor(0, 0x0000FFFF, (GDT_CODE_PL0)),
+        create_descriptor(0, 0x0000FFFF, (GDT_DATA_PL0)),
+        create_descriptor(0, 0x0000FFFF, (GDT_CODE_PL3)),
+        create_descriptor(0, 0x0000FFFF, (GDT_DATA_PL3)),
+    };
+
+    int gdt_index = 0;
+
+    while (gdt_index < GDT_DSC_CT) {
+        gdt_ptr[gdt_index] = gdt_entries[gdt_index];
+
+        gdt_index++;
+    }
+
+    return (uint16_t) sizeof(gdt_entries);
+}
+
+// space in memory for gdt
+
+uint64_t gdt_ptr[GDT_DSC_CT];

--- a/src/x86/boot/stage1.s
+++ b/src/x86/boot/stage1.s
@@ -8,11 +8,11 @@
 
 .code16
 
-.global _start
+.global _stage1
 
 .text
 
-_start:
+_stage1:
     xor %ax, %ax
     mov %ax, %ds                 # set data segment to 0
     mov %ax, %es                 # set extended segment to 0
@@ -108,7 +108,7 @@ lba_to_chs:
     mov %al, %dl                 # DL: boot device
     ret
     
-.include "src/x86/boot/text.s"
+.include "text.s"
 
 #  Disk info for converting LBA to CHS notation. Valid for a 1.44 MB floppy.
 #  Later on, we'll set these values dynamically using a BIOS function.
@@ -121,7 +121,7 @@ num_disk_retries: .word 3
 
 # first sector to read, and last sector (which doesn't get read)
 stage2_lba_start: .word 1
-stage2_lba_end: .word ((stage2_end - stage2_start + 511) / 512) + 1
+stage2_lba_end: .word ((_stage2_end - _stage2 + 511) / 512) + 1
 
 disk_error_msg: .ascii "Error reading disk."
 .byte 0x0A
@@ -134,14 +134,16 @@ success_msg: .ascii "Success, loading stage 2."
 .byte 0x00
 
 # bootloader must be 512 bytes long
-.fill 510-(. - _start), 1, 0
+.fill 510-(. - _stage1), 1, 0
 
 # magic number '0x55aa', that tells BIOS this binary is bootable 
 .word 0xaa55
 
+_stage1_end:
+
 # stage 2 binary
-stage2_start:
+_stage2:
 
-.incbin "build/x86/boot/bin/stage2.bin"
+.incbin "stage2.bin"
 
-stage2_end:
+_stage2_end:

--- a/src/x86/boot/stage2.s
+++ b/src/x86/boot/stage2.s
@@ -8,11 +8,11 @@
 
 .code16
 
-.global _start
+.global _stage2
 
 .text
 
-_start:
+_stage2:
     mov %cs, %ax            # code segment is 0x7e00
     mov %ax, %ds            # set data segment equal to code segment
     mov %ax, %es            # set extended segment equal to code segment
@@ -24,13 +24,14 @@ boot_success:
     mov $str_boot_success, %si
     call print_text
 _end:
-    sti                     # terminate with infinite loop
+    sti
     hlt
     jmp _end
 
 .data
 
-str_boot_success: .ascii "Booted successfully."
+str_boot_success: 
+.ascii "Booted!"
 .byte 0x0A
 .byte 0x0D
 .byte 0x00

--- a/src/x86/boot/text.s
+++ b/src/x86/boot/text.s
@@ -7,6 +7,9 @@
 .text
 
 print_text:
+    pushf
+    push %ax
+
     mov $0xe, %ah      # sets AH to 0xE (indicates teletype function)
 print_char:
     lodsb              # loads byte from SI into AL, and increments SI
@@ -15,4 +18,6 @@ print_char:
     int $0x10          # call teletype function, prints char in AL to screen
     jmp print_char     # loop back, print next char
 print_done:
-    ret                # loop back to beginning of print_msg, repeating for next char
+    pop %ax
+    popf
+    ret

--- a/targets/x86/boot/stage2.ld
+++ b/targets/x86/boot/stage2.ld
@@ -1,14 +1,21 @@
-ENTRY(_start)
+ENTRY(_stage2)
 OUTPUT_FORMAT(binary)
 SECTIONS
 {
     . = 0x0000;
     .stage2 : { 
-        build/x86/boot/stage2.o (.text) 
-        build/x86/boot/stage2.o (.data)
+        stage2.o (.text) 
     }
-    .protected : { 
-        build/x86/boot/protected_mode.o (.text)
-        build/x86/boot/protected_mode.o (.data)
+    .lib : { 
+        text.o (.text)
+        protected_mode.o (.text)
+        gdt.o (.text)
+    }
+    .data : {
+        stage2.o (.data)
+        protected_mode.o (.data)
+    }
+    .gdt : {
+        gdt.o (.data)
     }
 }


### PR DESCRIPTION
 - Add `gdt.c` source to stage 2 bootloader (will be used to set GDT)
 - Refactor `print_text` function (`text.s`) to no longer overwrite flags and `%ax` register
 - Use GCC to build assembly and C sources
 - Use separate `Makefile` per directory to build OS image from components
 - Update build output scheme 
    - GCC objects are now generated in `/targets/.../obj`
    - Compiled binary intermediates are now generated in `/targets/.../bin`
- Make `/env` directory hidden -> `/.env`